### PR TITLE
Fix inference pipeline bugs and improve compatibility

### DIFF
--- a/scripts/async_pi05/async_pi05_inference.py
+++ b/scripts/async_pi05/async_pi05_inference.py
@@ -260,7 +260,8 @@ class AsyncPi05Inference:
             return self.jit_sample_actions(rng, observation)
 
         sampled_actions = await self._run_blocking(_sample, use_model_lock=True)
-        return np.array(sampled_actions[0])
+        # sampled_actions is (x_0, output_tokens) tuple; x_0 shape is (1, action_horizon, action_dim)
+        return np.array(sampled_actions[0][0])
 
     async def infer(
         self,

--- a/src/openpi/models/pi05.py
+++ b/src/openpi/models/pi05.py
@@ -447,7 +447,9 @@ class Pi05(_model.BaseModel):
         num_steps: int | at.Int[at.Array, ""] = 10,
         noise: at.Float[at.Array, "b ah ad"] | None = None,
     ) -> _model.Actions:
-        observation = _model.preprocess_observation(None, observation, train=False)
+        observation = _model.preprocess_observation(
+            None, observation, train=False, image_keys=list(observation.images.keys())
+        )
         # note that we use the convention more common in diffusion literature, where t=1 is noise and t=0 is the target
         # distribution. yes, this is the opposite of the pi0 paper, and I'm sorry.
         dt = -1.0 / num_steps

--- a/src/openpi/models/tokenizer.py
+++ b/src/openpi/models/tokenizer.py
@@ -310,9 +310,13 @@ class PaligemmaTokenizer:
         return self._tokenizer.vocab_size() - 1 - self._fast_skip_tokens - tokens
 
     def detokenize(self, tokens: np.ndarray) -> str:
-        """Decode tokens back to text, removing padding tokens."""
+        """Decode tokens back to text, truncating at EOS and removing padding."""
         # Remove padding tokens (tokens with value 0)
         non_padding_tokens = tokens[tokens != 0]
+        # Truncate at first EOS token (token 1)
+        eos_positions = np.where(non_padding_tokens == 1)[0]
+        if len(eos_positions) > 0:
+            non_padding_tokens = non_padding_tokens[:eos_positions[0]]
         return self._tokenizer.decode(non_padding_tokens.tolist())
 
 

--- a/src/openpi/training/data_loader.py
+++ b/src/openpi/training/data_loader.py
@@ -146,7 +146,11 @@ def create_torch_dataset(
     )
 
     if data_config.prompt_from_task:
-        dataset = TransformedDataset(dataset, [_transforms.PromptFromLeRobotTask(dataset_meta.tasks)])
+        # Convert tasks to dict[int, str] if it's a DataFrame (lerobot >= 0.4.2 compat).
+        tasks = dataset_meta.tasks
+        if hasattr(tasks, "iterrows"):
+            tasks = dict(zip(tasks["task_index"], tasks.index))
+        dataset = TransformedDataset(dataset, [_transforms.PromptFromLeRobotTask(tasks)])
 
     return dataset
 


### PR DESCRIPTION
- Fix image_keys not passed to preprocess_observation() in sample_actions(), causing default key ordering to override the observation's actual key order
- Fix sampled_actions tuple indexing: sample_actions() returns (x_0, output_tokens) tuple, need [0][0] to get the action array
- Add EOS truncation in detokenize() to prevent decoded text from including tokens past the end-of-sequence marker
- Add lerobot >= 0.4.2 compatibility: handle tasks as DataFrame instead of dict